### PR TITLE
Improved LSP test and fixed the hover assertion

### DIFF
--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -93,6 +93,7 @@ def test_hover():
     payload_json = json.dumps(payload)
     payload_json_utf8 = payload_json.encode('utf-8')
 
+    print(f'Starting language server from {BINARY}')
     p = Popen([BINARY], stdout=PIPE, stdin=PIPE, stderr=PIPE)
 
     # get the first message after start

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -10,7 +10,7 @@ from subprocess import Popen, PIPE, STDOUT
 EXAMPLE_FOLDER = pathlib.Path(os.path.abspath(__file__)).parent
 EXAMPLE_FILE = EXAMPLE_FOLDER.joinpath('Hello.kt')
 
-BINARY = '../kotlin_kernel/java/bin/kotlin-language-server'
+BINARY = os.path.join(__file__, '..', '..', 'kotlin_kernel', 'java', 'bin', 'kotlin-language-server')
 BINARY = os.path.abspath(BINARY)
 
 LOG_LEVELS = {1: 'Error', 2: 'Warning', 3: 'Info', 4: 'Log'}

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -2,15 +2,26 @@ import os
 import json
 import pytest
 import platform
+import pathlib
 from .context import kotlin_kernel as kk
 from subprocess import Popen, PIPE, STDOUT
 
 
-EXAMPLE_FILE = './Hello.kt'
-EXAMPLE_FILE = os.path.abspath(EXAMPLE_FILE)
+EXAMPLE_FILE = os.path.join(__file__, '..', 'Hello.kt')
+EXAMPLE_FILE = pathlib.Path(os.path.abspath(EXAMPLE_FILE)).as_uri()
 
 BINARY = '../kotlin_kernel/java/bin/kotlin-language-server'
 BINARY = os.path.abspath(BINARY)
+
+
+def set_binary(path):
+    """
+    Sets the path to the language server binary. This function
+    can be used to conveniently swap the binary at runtime or
+    in an interactive shell.
+    """
+    global BINARY
+    BINARY = os.path.abspath(path)
 
 
 def send_header(proc, payload_length):
@@ -39,6 +50,28 @@ def send_body(proc, payload):
     """
     print(payload.encode('utf-8'))
     proc.stdin.write(payload.encode('utf-8'))
+    proc.stdin.flush()
+
+
+def read_message(proc):
+    """
+    Reads a message from the language server.
+    """
+    content_length = int(proc.stdout.readline()[16:])
+    proc.stdout.readline()  # read the \r\n
+    response = json.loads(proc.stdout.read(content_length))
+    if 'error' in response:
+      error = response['error']
+      print(error['message'])
+      print(error['data'].replace(r'\r\n', os.linesep))
+    return response
+
+
+def is_method(msg, method):
+    """
+    Tests whether a JSON-RPC message references a given method.
+    """
+    return ('method' in msg) and (msg['method'] == method)
 
 
 def test_hover():
@@ -48,7 +81,7 @@ def test_hover():
             'method': 'textDocument/hover',
             'params': {
               'textDocument': {
-                'uri': f'file://{EXAMPLE_FILE}'
+                'uri': EXAMPLE_FILE
               },
               'position': {
                 'line': 1,
@@ -63,16 +96,10 @@ def test_hover():
     p = Popen([BINARY], stdout=PIPE, stdin=PIPE, stderr=PIPE)
 
     # get the first message after start
-    content_length = int(p.stdout.readline()[16:])
-    p.stdout.readline()  # read the \r\n
-    response = json.loads(p.stdout.read(content_length))
-    print(response)
+    print(read_message(p))
 
     # get the second message after start
-    content_length = int(p.stdout.readline()[16:])
-    p.stdout.readline()  # read the \r\n
-    response = json.loads(p.stdout.read(content_length))
-    print(response)
+    print(read_message(p))
 
     # Now, ask for the hover message
     send_header(p, len(payload_json_utf8))
@@ -80,9 +107,9 @@ def test_hover():
     #written_bytes = p.stdin.write(msg)
     #assert written_bytes == len(msg)
 
-    content_length = int(p.stdout.readline()[16:])
-    p.stdout.readline()  # read the \r\n
-    response = json.loads(p.stdout.read(content_length))
-    print(response)
-
+    response = {'method': ''}
+    while not is_method(response, 'textDocument/hover'):
+      response = read_message(p)
+      print(response)
+    
     assert response.decode('utf-8').contains('inline fun')


### PR DESCRIPTION
I did some work to fix the language server initialization procedures, added some neat abstractions to ease communication with the server and fixed the hover test.

Tested using a Python 3.7.1 shell on Windows:

```python
>>> import tests.test_lsp as lsp
>>> lsp.set_binary(r"D:\git\KotlinLanguageServer\build\install\kotlin-language-server\bin\kotlin-language-server.bat") # Use different binary path, can be omitted to use the language server inside this repository (works only on Unix though)
>>> lsp.test_hover()
```

```
Starting language server from D:\git\KotlinLanguageServer\build\install\kotlin-language-server\bin\kotlin-language-server.bat
151
b'{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"processId": null, "rootUri": "file:///D:/git/kotlin_kernel/tests", "capabilities": {}}}'
{'jsonrpc': '2.0', 'id': '1', 'method': 'workspace/configuration', 'params': {'items': [{'section': 'kotlin'}]}}
[Info]     main      Connected to client
[Info]     client    Adding workspace file:///D:/git/kotlin_kernel/tests to source path
[Info]     client    Adding .../tests/Hello.kt under D:\git\kotlin_kernel\tests to source path
{'jsonrpc': '2.0', 'id': 1, 'result': {'capabilities': {'textDocumentSync': 2, 'hoverProvider': True, 'completionProvider': {'resolveProvider': False, 'triggerCharacters': ['.']}, 'signatureHelpProvider': {'triggerCharacters': ['(', ',']}, 'definitionProvider': True, 'referencesProvider': True, 'documentSymbolProvider': True, 'workspaceSymbolProvider': True, 'codeActionProvider': True, 'executeCommandProvider': {'commands': ['convertJavaToKotlin']}, 'workspace': {'workspaceFolders': {'supported': True, 'changeNotifications': True}}}}}184b'{"jsonrpc": "2.0", "id": 2, "method": "textDocument/hover", "params": {"textDocument": {"uri": "file:///D:/git/kotlin_kernel/tests/Hello.kt"}, "position": {"line": 1, "character": 9}}}'[Info]     async0    Hovering at file:///D:/git/kotlin_kernel/tests/Hello.kt 1:9
[Info]     async0    Re-parsing Hello.kt 0:1-3:2
[Info]     async0    Hovering CALL_EXPRESSION
[Info]     async0    Finished in 2710 ms
{'jsonrpc': '2.0', 'id': 2, 'result': {'contents': {'language': 'kotlin', 'value': 'inline fun println(message: Any?): Unit'}, 'range': {'start': {'line': 1, 'character': 4}, 'end': {'line': 1, 'character': 11}}}}
```

```python
>>>
```